### PR TITLE
onboarding videos does not play on release build

### DIFF
--- a/app/src/main/res/raw/keep.xml
+++ b/app/src/main/res/raw/keep.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools"
-    tools:keep="@layout/keep" />
+    tools:keep="@layout/keep, @raw/onboarding*" />


### PR DESCRIPTION

### Description
onboarding videos where shrink during release build. needed to mark them as not to be removed.
 
### Additional Notes (optional)
<!-- Provide any additional notes: quick tips for the reviewer, related PRs, screenshots, et al.). -->
 
### Checklist
<!-- Replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
 - [x] I am following the [code style guide](https://netguru.atlassian.net/wiki/display/ANDROID/Android+best+practices)
 - [x] The code includes tests of new features
 - [x] The code passes static analysis
 - [x] README.md is up to date
 - [x] Version number is up to date
 - [x] ProGuard configuration files are up to date
 - [x] All temporary TODOs and FIXMEs are removed
 - [x] I have tested the solution on these devices:
  * Samsung galaxy s9
  
### Merge
<!-- Mark person(s) allowed to perform merge to the target branch with [x] (can be multiple) -->
 - [x] Committer
 - [ ] Reviewer
 - [ ] Project lead